### PR TITLE
Add initial UI-backend interface object type and view models

### DIFF
--- a/src/NavigatorBackendType.ts
+++ b/src/NavigatorBackendType.ts
@@ -69,6 +69,13 @@ export type NavigatorBackend = {
     targetCommit: Commit,
   ): Promise<Commit>;
 
+  /**
+   * Amend the checked-out commit with the staged changes, then rebase this
+   * commit's dependents onto the ammended commit.
+   * @param repoPath Path to repository root.
+   */
+  amendAndRebaseDependentTree(repoPath: string): Promise<Commit>;
+
   createOrUpdatePRsForCommits(
     repoPath: string,
     commitStack: Commit[],

--- a/src/NavigatorBackendType.ts
+++ b/src/NavigatorBackendType.ts
@@ -1,0 +1,76 @@
+/**
+ * Stores the view models and interface types between the UI layer and its
+ * backend.
+ */
+
+/**
+ * A GitHub Pull Request, GitLab Merge Request, or similar.
+ */
+export interface PullRequestInfo {
+  url: string;
+  shortName: string;
+
+  isOutdated: boolean;
+}
+
+export interface Commit {
+  name: string;
+  hash: string;
+  timestamp: string;
+  author: string;
+  title: string;
+  branchNames: string[];
+  pullRequestInfo?: PullRequestInfo;
+
+  parentCommits: Commit[];
+  childCommits: Commit[];
+}
+
+export interface Repository {
+  path: string;
+  hasUncommittedChanges: boolean;
+  headHash: string;
+
+  /** The earliest interesting commit. */
+  rootDisplayCommit: Commit;
+}
+
+export type NavigatorBackend = {
+  // Getters
+  /**
+   * Asynchronously gets repository information.
+   * @param repoPath Path to repository root.
+   * @returns Cached repository information, along with a promise that returns
+   * the repository information updated with remote data (e.g. PRs).
+   */
+  getRepositoryInformation(
+    repoPath: string,
+  ): Promise<{
+    repo: Repository;
+    remoteRepoInfoPromise: Promise<Repository>;
+  }>;
+
+  // Actions
+  createOrUpdateBranchesForCommitStack(
+    repoPath: string,
+    commitStack: Commit[],
+  ): Promise<Commit[]>;
+
+  /**
+   * Uproot a commit tree and rebase it onto `targetCommit`.
+   * @param repoPath Path to repository root.
+   * @param rootCommit The commit tree root to be moved.
+   * @param targetCommit The commit the tree should be rebased on.
+   * @returns Updated `targetCommit`.
+   */
+  rebaseCommits(
+    repoPath: string,
+    rootCommit: Commit,
+    targetCommit: Commit,
+  ): Promise<Commit>;
+
+  createOrUpdatePRsForCommits(
+    repoPath: string,
+    commitStack: Commit[],
+  ): Promise<Commit[]>;
+};


### PR DESCRIPTION
The frontend will use an injected `NavigatorBackend`; I'll create a stub one first, but @saphal1998 and Jessie will be implementing one for the middle layer.

The `arc` equivalents can also be implemented using this as its backend.

These types should cover what's necessary for both milestones 1 and 2.

cc @manyaagarwal