### PR TITLE
[Frontend][4/n] Implement command infra and rebase marking

### DIFF
--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -9,15 +9,19 @@ interface GraphLineProps {
   commitDepth: number;
   hasFork: boolean;
   isFocused: boolean;
+  isBeingMoved: boolean;
 }
 const GraphLine: React.FC<GraphLineProps> = ({
   totalDepth,
   commitDepth,
   hasFork,
   isFocused,
+  isBeingMoved,
 }) => {
   const firstLine = Array.from({ length: totalDepth }, (_, i) => i)
-    .map((_, idx) => (idx === commitDepth ? (isFocused ? ">" : "*") : "|"))
+    .map((_, idx) =>
+      idx === commitDepth ? (isBeingMoved ? "@" : isFocused ? ">" : "*") : "|",
+    )
     .join(" ");
 
   const secondLineBars = Array.from(
@@ -43,11 +47,12 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
   displayCommit: {
     commit: { hash, timestamp, title, author, branchNames },
     isFocused,
+    isBeingMoved,
   },
 }) => {
   return (
     <Box flexDirection="row">
-      <Text>
+      <Text dimColor={isBeingMoved}>
         <Text
           color="blueBright"
           backgroundColor={isFocused ? "yellow" : "none"}>
@@ -82,6 +87,7 @@ const CommitGraph: React.FC<CommitGraphProps> = ({ displayCommits }) => (
           commitDepth={displayCommit.commitDepth}
           hasFork={displayCommit.hasFork}
           isFocused={displayCommit.isFocused}
+          isBeingMoved={displayCommit.isBeingMoved}
         />
         <CommitInfo displayCommit={displayCommit} />
       </Box>

--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -103,9 +103,11 @@ export const RepositoryComponent: React.FC<RepositoryComponentProps> = ({
     if (input === "q") {
       exit();
     } else if (key.upArrow) {
-      dispatch({ type: "move up" });
+      dispatch({ type: "key", payload: { key: "↑" } });
     } else if (key.downArrow) {
-      dispatch({ type: "move down" });
+      dispatch({ type: "key", payload: { key: "↓" } });
+    } else {
+      dispatch({ type: "key", payload: { key: input } });
     }
   });
 


### PR DESCRIPTION
## Summary

* Implements command infra: you can define keyboard command objects with handlers that operate on state.
* Implements marking of commits to rebase.

The UI that displays the available commands (the "TODO: Line of commands") will be implemented in a future PR.

## Test plan

`yarn cli`:

1. Use up/down arrows to navigate to a commit to rebase.
	![image](https://user-images.githubusercontent.com/12784593/87515699-ce8a4a00-c6ae-11ea-8aca-59d081611e31.png)
1. Press `r` to begin rebase. The commits rooted at the focused commit will be marked for moving, and the focus will be shifted to the rebase root parent. The focused commit is the rebase target. A future PR will allow the selection of a different rebase target; for now, arrow keys in this state do nothing.
	![image](https://user-images.githubusercontent.com/12784593/87515766-e95cbe80-c6ae-11ea-99a0-b77947cfd84b.png)
1. Press `a` to abort rebase.
	![image](https://user-images.githubusercontent.com/12784593/87515882-18733000-c6af-11ea-8e7d-5fdae36ff02b.png)