### PR TITLE
[Frontend][5/n] Implement in-memory rebase and UI

### DIFF
--- a/src/NavigatorInMemoryBackend.ts
+++ b/src/NavigatorInMemoryBackend.ts
@@ -69,7 +69,20 @@ export const backend: NavigatorBackend = {
   },
 
   rebaseCommits(repoPath: string, rootCommit: Commit, targetCommit: Commit) {
-    return Promise.reject("NOT IMPLEMENTED");
+    if (rootCommit === targetCommit) {
+      return Promise.reject("Circular reference!");
+    }
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        rootCommit.parentCommits[0].childCommits.splice(
+          rootCommit.parentCommits[0].childCommits.indexOf(rootCommit),
+          1,
+        );
+        rootCommit.parentCommits = [targetCommit];
+        targetCommit.childCommits.push(rootCommit);
+        resolve(targetCommit);
+      }, 200);
+    });
   },
 
   amendAndRebaseDependentTree(repoPath: string) {

--- a/src/NavigatorInMemoryBackend.ts
+++ b/src/NavigatorInMemoryBackend.ts
@@ -1,11 +1,13 @@
 import type { Commit, NavigatorBackend } from "./NavigatorBackendType";
 
+import { Signature } from "nodegit";
+
 function makeCommits() {
   const existingStuffCommit: Commit = {
     title: "Existing stuff",
     hash: "1234",
     timestamp: new Date(0),
-    author: "Commit McCommitFace",
+    author: Signature.create("Commit McCommitFace", "wotface@wot.face", 0, 0),
     branchNames: ["master"],
     parentCommits: [],
     childCommits: [],
@@ -15,7 +17,7 @@ function makeCommits() {
     title: "Other peoples trash",
     hash: "1235",
     timestamp: new Date(100),
-    author: "Commit McCommitFace",
+    author: Signature.create("Commit McCommitFace", "wotface@wot.face", 100, 0),
     branchNames: ["origin/master"],
     parentCommits: [existingStuffCommit],
     childCommits: [],
@@ -26,7 +28,7 @@ function makeCommits() {
     title: "1",
     hash: "abc1",
     timestamp: new Date(1),
-    author: "Commit McCommitFace",
+    author: Signature.create("Commit McCommitFace", "wotface@wot.face", 1, 0),
     branchNames: [],
     parentCommits: [existingStuffCommit],
     childCommits: [],
@@ -37,7 +39,7 @@ function makeCommits() {
     title: "2",
     hash: "abc2",
     timestamp: new Date(2),
-    author: "Commit McCommitFace",
+    author: Signature.create("Commit McCommitFace", "wotface@wot.face", 2, 0),
     branchNames: [],
     parentCommits: [commit1],
     childCommits: [],

--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -31,7 +31,7 @@ const App: React.FC<Props> = ({ backend, repoPath }) => {
     return <Text>{isLoading ? "Loading" : "Could not load repo"}</Text>;
   }
 
-  return <RepositoryComponent repository={repository} />;
+  return <RepositoryComponent backend={backend} repository={repository} />;
 };
 
 export default App;

--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -68,7 +68,7 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
           )}
         </Box>
         <Text>
-          {title} - <Text color="blueBright">{author}</Text>
+          {title} - <Text color="blueBright">{author.toString()}</Text>
         </Text>
       </Box>
     </Box>

--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -1,4 +1,4 @@
-import type { Repository } from "../NavigatorBackendType";
+import type { Repository, NavigatorBackend } from "../NavigatorBackendType";
 
 import React from "react";
 import { Text, Box, useInput, useApp } from "ink";
@@ -96,24 +96,26 @@ const CommitGraph: React.FC<CommitGraphProps> = ({ displayCommits }) => (
 );
 
 interface RepositoryComponentProps {
+  backend: NavigatorBackend;
   repository: Repository;
 }
 export const RepositoryComponent: React.FC<RepositoryComponentProps> = ({
+  backend,
   repository,
 }) => {
   const { exit } = useApp();
 
-  const [state, dispatch] = useInteractionReducer(repository);
+  const [state, dispatch] = useInteractionReducer(backend, repository);
 
   useInput((input, key) => {
     if (input === "q") {
       exit();
     } else if (key.upArrow) {
-      dispatch({ type: "key", payload: { key: "↑" } });
+      dispatch({ type: "key", payload: { key: "↑", dispatch } });
     } else if (key.downArrow) {
-      dispatch({ type: "key", payload: { key: "↓" } });
+      dispatch({ type: "key", payload: { key: "↓", dispatch } });
     } else {
-      dispatch({ type: "key", payload: { key: input } });
+      dispatch({ type: "key", payload: { key: input, dispatch } });
     }
   });
 

--- a/src/cli/useInteractionReducer.ts
+++ b/src/cli/useInteractionReducer.ts
@@ -1,4 +1,4 @@
-import { Repository, Commit } from "../NavigatorBackendType";
+import { Repository, Commit, NavigatorBackend } from "../NavigatorBackendType";
 import { useReducer, useEffect } from "react";
 
 export type DisplayCommit = {
@@ -18,7 +18,7 @@ export type DisplayCommit = {
 type Command = {
   key: string;
   name: string;
-  handler: (state: State) => State;
+  handler: (state: State, action: KeyAction) => State;
 };
 
 type NormalModeState = {
@@ -32,6 +32,7 @@ type RebaseModeState = {
 };
 
 type State = {
+  backend: NavigatorBackend;
   repository: Repository;
   commits: DisplayCommit[];
   modeState: NormalModeState | RebaseModeState;
@@ -45,6 +46,7 @@ const initialState: Pick<State, "modeState" | "keyboardCommands"> = {
 type InitializeAction = {
   type: "initialize";
   payload: {
+    backend: NavigatorBackend;
     repository: Repository;
   };
 };
@@ -52,6 +54,7 @@ type KeyAction = {
   type: "key";
   payload: {
     key: string;
+    dispatch: React.Dispatch<Action>;
   };
 };
 type Action = InitializeAction | KeyAction;
@@ -123,9 +126,13 @@ function backendCommitGraphToDisplayCommits(
   return displayCommits;
 }
 
-function initializedState(repository: Repository): State {
+function initializedState(
+  backend: NavigatorBackend,
+  repository: Repository,
+): State {
   return stateForNormalMode({
     ...initialState,
+    backend,
     repository,
     commits: backendCommitGraphToDisplayCommits(repository.rootDisplayCommit),
   });
@@ -372,27 +379,31 @@ function stateForRebaseMode(state: State): State {
 function reducer(state: Readonly<State>, action: Action): State {
   switch (action.type) {
     case "initialize": {
-      return initializedState(action.payload.repository);
+      return initializedState(
+        action.payload.backend,
+        action.payload.repository,
+      );
     }
     case "key": {
       const command = state.keyboardCommands.get(action.payload.key);
       if (!command) {
         return state;
       }
-      return command.handler(state);
+      return command.handler(state, action);
     }
   }
 }
 
 export function useInteractionReducer(
+  backend: NavigatorBackend,
   repository: Repository,
 ): [State, React.Dispatch<Action>] {
   const [state, dispatch] = useReducer(reducer, {}, () =>
-    initializedState(repository),
+    initializedState(backend, repository),
   );
 
   useEffect(() => {
-    dispatch({ type: "initialize", payload: { repository } });
+    dispatch({ type: "initialize", payload: { backend, repository } });
   }, [repository]);
 
   return [state, dispatch];

--- a/src/cli/useInteractionReducer.ts
+++ b/src/cli/useInteractionReducer.ts
@@ -297,6 +297,52 @@ function stateForRebaseMode(state: State): State {
     },
     keyboardCommands: new Map([
       [
+        "↑",
+        {
+          key: "↑",
+          name: "next rebase target",
+          handler: (state) => ({
+            ...state,
+            commits: commitsWithMovedFocus(state.commits, (focusIndex) => {
+              const numCommits = state.commits.length;
+              let proposedIndex = focusIndex ?? 0;
+              let i = 0; // Prevents infinite loops
+              do {
+                proposedIndex = (proposedIndex + 1) % numCommits;
+                i++;
+                if (i > numCommits) {
+                  return focusIndex ?? 0;
+                }
+              } while (state.commits[proposedIndex].isBeingMoved);
+              return proposedIndex;
+            }),
+          }),
+        },
+      ],
+      [
+        "↓",
+        {
+          key: "↓",
+          name: "previous rebase target",
+          handler: (state) => ({
+            ...state,
+            commits: commitsWithMovedFocus(state.commits, (focusIndex) => {
+              const numCommits = state.commits.length;
+              let proposedIndex = focusIndex ?? numCommits;
+              let i = 0; // Prevents infinite loops
+              do {
+                proposedIndex = (proposedIndex - 1 + numCommits) % numCommits;
+                i++;
+                if (i > numCommits) {
+                  return focusIndex ?? 0;
+                }
+              } while (state.commits[proposedIndex].isBeingMoved);
+              return proposedIndex;
+            }),
+          }),
+        },
+      ],
+      [
         "a",
         {
           key: "a",


### PR DESCRIPTION
* Makes `dispatch` and `backend` accessible to our command handlers.
* `Commit.author` now stores the timestamp of the commit, which is a duplicate of our `Commit.timestamp` field. This should be fixed, but as the cause is in a different PR and everything still works now, it's outside the scope of this PR.

More details in the test plan.

## Test Plan

`yarn cli`

* In rebase mode, up/down arrows navigate between possible rebase targets
* `c` key confirms the rebase
* After rebase, the commit tree appears correctly

![image](https://user-images.githubusercontent.com/12784593/87635028-f6da7d00-c770-11ea-92bb-1e435bcfa392.png)

![image](https://user-images.githubusercontent.com/12784593/87635042-0063e500-c771-11ea-8dca-43c7638c816e.png)

Commit trees are displayed wrongly in many cases, but that's outside the scope of this PR. In the below screenshot, commit `1235` is a child of `abc1`, but `abc2` and `1235` are displayed out of order.

![image](https://user-images.githubusercontent.com/12784593/87635144-2a1d0c00-c771-11ea-8d82-15cacffe7b54.png)
