### PR TITLE
[Frontend][7/n] Implement PR commands and improve narrow screen display

### DIFF
--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -106,8 +106,10 @@ const CommandList: React.FC<CommandListProps> = ({ commands }) => (
   <Box marginTop={1}>
     {commands.map(({ key, name }) => (
       <Box key={key} marginRight={2}>
-        <Text color="white">({key})</Text>
-        <Text color="gray"> {name}</Text>
+        <Box marginRight={1} flexShrink={0}>
+          <Text color="white">({key})</Text>
+        </Box>
+        <Text color="gray">{name}</Text>
       </Box>
     ))}
   </Box>

--- a/src/cli/useInteractionReducer.ts
+++ b/src/cli/useInteractionReducer.ts
@@ -232,6 +232,69 @@ function stateForNormalMode(state: State): State {
           },
         },
       ],
+      [
+        "c",
+        {
+          key: "c",
+          name: "PR single commit",
+          handler(state, { payload: { dispatch } }) {
+            const { commits, backend, repository } = state;
+
+            const focusedCommitIndex = indexOfFocusedCommit(commits);
+            // Bail if no focus
+            if (focusedCommitIndex === -1) {
+              return state;
+            }
+            const stackBase = commits[focusedCommitIndex].commit;
+
+            backend
+              .createOrUpdatePRsForCommits(repository.path, [stackBase])
+              .then(() =>
+                dispatch({
+                  type: "initialize",
+                  payload: { backend, repository },
+                }),
+              );
+            return state;
+          },
+        },
+      ],
+      [
+        "s",
+        {
+          key: "s",
+          name: "PR stack",
+          handler(state, { payload: { dispatch } }) {
+            const { commits, backend, repository } = state;
+
+            const focusedCommitIndex = indexOfFocusedCommit(commits);
+            // Bail if no focus
+            if (focusedCommitIndex === -1) {
+              return state;
+            }
+            const stackBase = commits[focusedCommitIndex].commit;
+
+            // Traverse tree to build commit stack
+            const stack = [];
+            const nextCommits = [stackBase];
+            while (nextCommits.length) {
+              const nextCommit = nextCommits.pop()!;
+              stack.push(nextCommit);
+              nextCommits.push(...nextCommit.childCommits);
+            }
+
+            backend
+              .createOrUpdatePRsForCommits(repository.path, stack)
+              .then(() =>
+                dispatch({
+                  type: "initialize",
+                  payload: { backend, repository },
+                }),
+              );
+            return state;
+          },
+        },
+      ],
     ]),
   };
 }


### PR DESCRIPTION
## Summary

1. Implements PR keyboard commands. These currently crash as they're not implemented in the backend. In normal mode:
	* `c` creates a new PR for a single commit
	* `s` creates a stack of PRs for a stack of commits
1. Narrow screen display is improved slightly; the key text (e.g. `(r)`) no longer shrinks.


## Test Plan

`yarn cli`.

1. Display in a narrow terminal
1. Press c or s in normal mode. Crashes.

![image](https://user-images.githubusercontent.com/12784593/87651198-4f1b7a00-c785-11ea-81c1-40a1867a5ee2.png)
