### PR TITLE
Initial integration of GitLocal be with fe and fix getRepositoryInformation

### DIFF
--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -60,7 +60,7 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
         <Text
           color="blueBright"
           backgroundColor={isFocused ? "yellow" : "none"}>
-          {hash}
+          {hash.substr(0, 6)}
         </Text>{" "}
         -{" "}
       </Text>

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,9 +2,9 @@
 import React from "react";
 import { render } from "ink";
 import meow from "meow";
-import { backend } from "../NavigatorInMemoryBackend";
 
 import App from "./App";
+import { GitLocal } from "../local-git/GitLocalInterface";
 
 const cli = meow(`
 	Usage
@@ -18,7 +18,7 @@ const cli = meow(`
 render(
   React.createElement(App, {
     // TODO: replace with Git backend
-    backend,
+    backend: new GitLocal(),
     repoPath: cli.input[0] ?? process.cwd(),
   }),
 );


### PR DESCRIPTION
## Summary

Conflicts with #13; this PR should be merged before that as we know this one works.

Fixes the following bugs in `getRepositoryInformation`:

* The branch names were injected from the root branch were were starting from, resulting in all commits having the top-most branch that the traversal started from.
* The on commit handler stopeed when it encountered a commit it's seen before without updating children relationships.
* The common ancestor commit was endowed with all the known branches instead of only its own.

## Other notes

* Removes `shaToCommit` as it is now only used once and performs a redundant fetch. This will be major source of conflict with #13.
* `getRepositoryInformation` still calls `getPullRequestInfo` for each commit, which is not intended as we'll then need to wait for network calls to complete before being able to render. We will fix this in #13.

## Test Plan

After initial integration (and after hashes were truncated):

* Only one branch is visible
* Many commits had branches that it should not have
* A second branch from commit `422c27` was missing

![image](https://user-images.githubusercontent.com/12784593/87666208-c60f3d80-c79a-11ea-8935-0abc2e8aa62d.png)

After fixes:

![image](https://user-images.githubusercontent.com/12784593/87666428-31590f80-c79b-11ea-80f8-66ea72d4963e.png)
