### PR TITLE
Implement commit stack rebase

### DIFF
--- a/src/local-git/GitLocalInterface.ts
+++ b/src/local-git/GitLocalInterface.ts
@@ -263,11 +263,14 @@ export class GitLocal implements NavigatorBackend {
     commitStack: Commit[],
   ): Promise<Commit[]> {
     const repo = await nodegit.Repository.open(repoPath);
-    for (const [i, element] of commitStack.entries()) {
+    for (let i = 0; i < commitStack.length; i++) {
       const commitMessage = "feature/new-branch"; // TODO: get the branch name from user
       const newBranchName = `${commitMessage}-${i}`; // Branch name is "commit message-branch number"
-      element.branchNames.push(newBranchName);
-      const commitTarget = await nodegit.Commit.lookup(repo, element.hash);
+      commitStack[i].branchNames.push(newBranchName);
+      const commitTarget = await nodegit.Commit.lookup(
+        repo,
+        commitStack[i].hash,
+      );
       await nodegit.Branch.create(repo, newBranchName, commitTarget, 1);
     }
 

--- a/src/local-git/GitLocalInterface.ts
+++ b/src/local-git/GitLocalInterface.ts
@@ -300,12 +300,14 @@ export class GitLocal implements NavigatorBackend {
       // Can have multiple names so, git reset HARD :check:
       childCommit.branchNames.map(async (branchName: string) => {
         // Target Commit Lookup will change if we use CherryPick
-        const reference = await nodegit.Branch.create(
-          repo,
-          branchName,
-          targetCommitLookup,
-          1,
-        );
+        if (branchName.startsWith("refs/heads/")) {
+          const reference = await nodegit.Branch.create(
+            repo,
+            branchName,
+            targetCommitLookup,
+            1,
+          );
+        }
       });
       commitToRebase = childCommitLookup;
       stackAttackCommit = childCommit;


### PR DESCRIPTION
Using [CherryPicking Example](https://github.com/nodegit/nodegit/blob/8a59c1cbedf8f70404ebc923f9d212052a4205ca/test/tests/cherrypick.js#L56) as reference, we use CherryPick to `mock-Rebase` our rootCommit on the targetCommit. 

We also use [nodegit.Branch.create](https://www.nodegit.org/api/branch/#create) to mimic 'git reset --HARD'.