### PR TITLE
Implement app reload on rebase and PR

### DIFF
--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -129,10 +129,12 @@ const CommandList: React.FC<CommandListProps> = ({ commands }) => (
 interface RepositoryComponentProps {
   backend: NavigatorBackend;
   repository: Repository;
+  reload: () => void;
 }
 export const RepositoryComponent: React.FC<RepositoryComponentProps> = ({
   backend,
   repository,
+  reload,
 }) => {
   const { exit } = useApp();
 
@@ -142,11 +144,11 @@ export const RepositoryComponent: React.FC<RepositoryComponentProps> = ({
     if (input === "q") {
       exit();
     } else if (key.upArrow) {
-      dispatch({ type: "key", payload: { key: "↑", dispatch } });
+      dispatch({ type: "key", payload: { key: "↑", dispatch, reload } });
     } else if (key.downArrow) {
-      dispatch({ type: "key", payload: { key: "↓", dispatch } });
+      dispatch({ type: "key", payload: { key: "↓", dispatch, reload } });
     } else {
-      dispatch({ type: "key", payload: { key: input, dispatch } });
+      dispatch({ type: "key", payload: { key: input, dispatch, reload } });
     }
   });
 

--- a/src/cli/useInteractionReducer.ts
+++ b/src/cli/useInteractionReducer.ts
@@ -53,6 +53,7 @@ type KeyAction = {
   payload: {
     key: string;
     dispatch: React.Dispatch<Action>;
+    reload: () => void;
   };
 };
 type Action = InitializeAction | KeyAction;
@@ -241,7 +242,7 @@ function stateForNormalMode(state: State): State {
         {
           key: "c",
           name: "PR single commit",
-          handler(state, { payload: { dispatch } }) {
+          handler(state, { payload: { reload } }) {
             const { commits, backend, repository } = state;
 
             const focusedCommitIndex = indexOfFocusedCommit(commits);
@@ -254,12 +255,7 @@ function stateForNormalMode(state: State): State {
 
             backend
               .createOrUpdatePRsForCommits(repository.path, [stackBase])
-              .then(() =>
-                dispatch({
-                  type: "initialize",
-                  payload: { backend, repository },
-                }),
-              );
+              .then(() => reload());
             return state;
           },
         },
@@ -269,7 +265,7 @@ function stateForNormalMode(state: State): State {
         {
           key: "s",
           name: "PR stack",
-          handler(state, { payload: { dispatch } }) {
+          handler(state, { payload: { reload } }) {
             const { commits, backend, repository } = state;
 
             const focusedCommitIndex = indexOfFocusedCommit(commits);
@@ -291,12 +287,7 @@ function stateForNormalMode(state: State): State {
 
             backend
               .createOrUpdatePRsForCommits(repository.path, stack)
-              .then(() =>
-                dispatch({
-                  type: "initialize",
-                  payload: { backend, repository },
-                }),
-              );
+              .then(() => reload());
             return state;
           },
         },
@@ -450,7 +441,7 @@ function stateForRebaseMode(state: State): State {
         {
           key: "c",
           name: "confirm rebase",
-          handler(state, { payload: { dispatch } }) {
+          handler(state, { payload: { reload } }) {
             if (state.modeState.type !== "rebase") {
               return state;
             }
@@ -476,12 +467,7 @@ function stateForRebaseMode(state: State): State {
                 rebaseRoot.commit,
                 rebaseTarget.commit,
               )
-              .then(() =>
-                dispatch({
-                  type: "initialize",
-                  payload: { backend, repository },
-                }),
-              );
+              .then(() => reload());
             return state;
           },
         },

--- a/src/local-git/GitLocalInterface.ts
+++ b/src/local-git/GitLocalInterface.ts
@@ -375,7 +375,7 @@ export class GitLocal implements NavigatorBackend {
     // Remove temp branch
     nodegit.Branch.delete(await repo.getBranch(tempBranchName));
 
-    // TODO: Abandon this updated-commit strategy and just reload the entire app!
+    // TODO: Update the commit data and use it in the frontend
     return rootCommit;
   }
 


### PR DESCRIPTION
## Test Plan

`yarn cli`:

1. PR information appears immediately when available.
1. Confirming a rebase reloads the app, showing the resulting commit graph.
1. PR completion should also reload the app, but this is untested as #16 is not merged.