### PR TITLE
Publish sttack package on NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,21 @@
 {
   "name": "sttack",
+  "description": "A CLI tool that manages stacked pull requests. Using stacked PRs is now (many small) pieces of cake.",
   "version": "0.0.0",
   "license": "MIT",
-  "bin": "cli.js",
+  "bin": "dist/cli/index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=12.4.0"
   },
   "scripts": {
     "cli": "ts-node ./src/cli/index.ts",
     "cli:watch": "nodemon -I -x ts-node -e ts,tsx ./src/cli/index.ts",
-    "build": "tsc",
+    "clean": "rm -rf dist",
+    "build": "tsc --project tsconfig.dist.json && chmod +x dist/cli/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "xo && jest"
+    "test": "xo && jest",
+    "prepare": "yarn clean && yarn build"
   },
-  "files": [
-    "dist/cli.js",
-    "dist/ui.js"
-  ],
   "dependencies": {
     "@octokit/rest": "^18.0.0",
     "ink": "3.0.0-6",

--- a/packages/stack-attack/README.md
+++ b/packages/stack-attack/README.md
@@ -1,0 +1,3 @@
+# Stack Attack
+
+Reserved to prevent confusion with https://www.npmjs.com/package/sttack.

--- a/packages/stack-attack/index.js
+++ b/packages/stack-attack/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+console.log("Thanks for downloading Stack Attack!");
+console.log("You probably want the sttack package instead.");

--- a/packages/stack-attack/package.json
+++ b/packages/stack-attack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sttack-attack",
+  "name": "stack-attack",
   "description": "Renamed -> sttack",
   "version": "1.0.1",
   "license": "MIT",

--- a/packages/stack-attack/package.json
+++ b/packages/stack-attack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sttack-attack",
   "description": "Renamed -> sttack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "bin": "index.js"
 }

--- a/packages/stack-attack/package.json
+++ b/packages/stack-attack/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sttack-attack",
+  "description": "Renamed -> sttack",
+  "version": "1.0.0",
+  "license": "MIT",
+  "bin": "index.js"
+}

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,15 @@ tools, and implements their workflow for everyone else.
    Note: You can generate a GitHub personal access token
    [here](https://github.com/settings/tokens).
 
-1. Run `npx sttack [repo_path]` to start Stack Attack.
+1. Install Stack Attack by running:
+
+   ```sh
+   yarn global add sttack
+   # OR
+   npm install -g sttack
+   ```
+
+1. Run `sttack` in your repository to start Stack Attack!
 
 ### From Source
 

--- a/readme.md
+++ b/readme.md
@@ -107,14 +107,14 @@ tools, and implements their workflow for everyone else.
    Note: You can generate a GitHub personal access token
    [here](https://github.com/settings/tokens).
 
-1. Run `npx sttack <repo_path>` to start Stack Attack.
+1. Run `npx sttack [repo_path]` to start Stack Attack.
 
 ### From Source
 
 1. Clone this repository.
 1. Run `yarn` to install our dependencies.
 1. Create a `<repo_path>/sttack.config.json` file as above.
-1. Run `yarn cli <repo_path>` to start Stack Attack.
+1. Run `yarn cli [repo_path]` to start Stack Attack.
 
 ### General Tips
 

--- a/readme.md
+++ b/readme.md
@@ -87,8 +87,8 @@ tools, and implements their workflow for everyone else.
 
 ## Usage
 
-1. Clone this repository.
-1. Run `yarn` to install our dependencies.
+### From NPM
+
 1. Add a `<repo_path>/sttack.config.json` file, where `<repo_path>` is the local
    path to the repository you want to run Stack Attack on. The config file
    should contain the following:
@@ -107,6 +107,13 @@ tools, and implements their workflow for everyone else.
    Note: You can generate a GitHub personal access token
    [here](https://github.com/settings/tokens).
 
+1. Run `npx sttack <repo_path>` to start Stack Attack.
+
+### From Source
+
+1. Clone this repository.
+1. Run `yarn` to install our dependencies.
+1. Create a `<repo_path>/sttack.config.json` file as above.
 1. Run `yarn cli <repo_path>` to start Stack Attack.
 
 ### General Tips

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/test-util"]
+}


### PR DESCRIPTION
We're on NPM! 🍉

![image](https://user-images.githubusercontent.com/12784593/88165875-f6e2ed00-cc48-11ea-8f2a-65d4f3a0ac33.png)

* Main package: https://www.npmjs.com/package/sttack
* Packages to prevent confusion/malicious packages:
	* https://www.npmjs.com/package/stack-attack
	* https://www.npmjs.com/package/sttack-attack (I accidentally typoed stack and deployed)

README updated.

Although `npx sttack` would have been ideal instead of asking users to install, it isn't working on my machine (WSL2 Ubuntu 18.04.4) as libgit2 spews out many errors. It'll be great if you could try it on your respective OSes; if it works we may want to update our README to recommend that.

## Test Plan

1. `npx sttack-attack` and `npx stack-attack`
	![image](https://user-images.githubusercontent.com/12784593/88165229-f5fd8b80-cc47-11ea-965e-dc9f045728af.png)

1. `yarn global add sttack`

1. `sttack`
	![image](https://user-images.githubusercontent.com/12784593/88165136-cea6be80-cc47-11ea-8ec1-6f8d17fecb40.png)