### PR TITLE
Update frontend to use new Stacker backend

### DIFF
--- a/src/cli/App.tsx
+++ b/src/cli/App.tsx
@@ -1,46 +1,26 @@
-import type { NavigatorBackend, Repository } from "../NavigatorBackendType";
+import type { Stacker } from "../stacker";
+import type { Repository } from "../shared/types";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React from "react";
 import { Text } from "ink";
 import { RepositoryComponent } from "./RepositoryComponent";
 
 interface Props {
-  repoPath: string;
-  backend: NavigatorBackend;
+  stacker: Stacker;
+  repository: Repository | null;
+  reload: () => void;
 }
 
-const App: React.FC<Props> = ({ backend, repoPath }) => {
-  const [repository, setRepository] = useState<Repository>();
-  const [isLoading, setIsLoading] = useState(false);
-
-  async function reload() {
-    setIsLoading(true);
-    const {
-      repo,
-      remoteRepoInfoPromise,
-    } = await backend.getRepositoryInformation(repoPath);
-    setRepository({ ...repo });
-    setIsLoading(false);
-    setRepository({ ...(await remoteRepoInfoPromise) });
-  }
-
-  useEffect(() => {
-    reload();
-  }, [backend, repoPath]);
-
-  if (isLoading) {
-    return <Text>Loading</Text>;
-  }
-
+const App: React.FC<Props> = ({ stacker, repository, reload }) => {
   if (!repository) {
-    return <Text>Could not load repo</Text>;
+    return <Text>Loading</Text>;
   }
 
   return (
     <RepositoryComponent
-      reload={reload}
-      backend={backend}
+      stacker={stacker}
       repository={repository}
+      reload={reload}
     />
   );
 };

--- a/src/cli/RepositoryComponent.tsx
+++ b/src/cli/RepositoryComponent.tsx
@@ -1,4 +1,5 @@
-import type { Repository, NavigatorBackend } from "../NavigatorBackendType";
+import type { Stacker } from "../stacker";
+import type { Repository } from "../shared/types";
 
 import React from "react";
 import { Text, Box, useInput, useApp } from "ink";
@@ -55,7 +56,7 @@ interface CommitInfoProps {
 }
 const CommitInfo: React.FC<CommitInfoProps> = ({
   displayCommit: {
-    commit: { hash, timestamp, title, author, branchNames, pullRequestInfo },
+    commit: { hash, timestamp, title, author, refNames, pullRequestInfo },
     isFocused,
     isBeingMoved,
   },
@@ -73,8 +74,8 @@ const CommitInfo: React.FC<CommitInfoProps> = ({
       <Box flexDirection="column">
         <Box>
           <Text color="cyan">{timestamp.toISOString()}</Text>
-          {branchNames.length > 0 && (
-            <Text color="greenBright">{` (${branchNames.join(", ")})`}</Text>
+          {refNames.length > 0 && (
+            <Text color="greenBright">{` (${refNames.join(", ")})`}</Text>
           )}
         </Box>
         <Text>{title}</Text>
@@ -127,18 +128,18 @@ const CommandList: React.FC<CommandListProps> = ({ commands }) => (
 );
 
 interface RepositoryComponentProps {
-  backend: NavigatorBackend;
+  stacker: Stacker;
   repository: Repository;
   reload: () => void;
 }
 export const RepositoryComponent: React.FC<RepositoryComponentProps> = ({
-  backend,
+  stacker,
   repository,
   reload,
 }) => {
   const { exit } = useApp();
 
-  const [state, dispatch] = useInteractionReducer(backend, repository);
+  const [state, dispatch] = useInteractionReducer(stacker, repository);
 
   useInput((input, key) => {
     if (input === "q") {

--- a/src/collaboration-platform/index.ts
+++ b/src/collaboration-platform/index.ts
@@ -1,0 +1,2 @@
+export * from "./CollaborationPlatform";
+export * from "./GitHubCollaborationPlatform";

--- a/src/shared/constructStacker.ts
+++ b/src/shared/constructStacker.ts
@@ -1,0 +1,17 @@
+import type { Stacker, StackerRepositoryUpdateListener } from "../stacker";
+
+import { GitSourceControl } from "../source-control";
+import { GitHubCollaborationPlatform } from "../collaboration-platform";
+import { ConcreteStacker } from "../stacker";
+
+export function constructStacker(
+  repoPath: string,
+  repositoryUpdateListener: StackerRepositoryUpdateListener,
+): Stacker {
+  return new ConcreteStacker(
+    repoPath,
+    repositoryUpdateListener,
+    new GitHubCollaborationPlatform(repoPath),
+    (stackerListener) => new GitSourceControl(repoPath, stackerListener),
+  );
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,7 +40,15 @@ export interface Commit {
 export interface Repository {
   path: string;
   hasUncommittedChanges: boolean;
-  headHash: string;
+  headHash: CommitHash;
 
   earliestInterestingCommit: Commit;
+
+  /**
+   * All relevant commits in the repository.
+   *
+   * This is not a `Map` as we need to be able to detect that this object has
+   * changed. We could revisit this decision again in the future.
+   */
+  commits: { [hash: string]: Commit };
 }

--- a/src/source-control/index.ts
+++ b/src/source-control/index.ts
@@ -1,0 +1,2 @@
+export * from "./GitSourceControl";
+export * from "./SourceControl";

--- a/src/stacker/ConcreteStacker.ts
+++ b/src/stacker/ConcreteStacker.ts
@@ -1,5 +1,8 @@
-import type { Commit } from "../shared/types";
-import type { SourceControl } from "../source-control/SourceControl";
+import type { Commit, Repository } from "../shared/types";
+import type {
+  SourceControl,
+  SourceControlRepositoryUpdateListener,
+} from "../source-control/SourceControl";
 import type { CollaborationPlatform } from "../collaboration-platform/CollaborationPlatform";
 import type { Stacker, StackerRepositoryUpdateListener } from "./Stacker";
 
@@ -11,21 +14,31 @@ import type { Stacker, StackerRepositoryUpdateListener } from "./Stacker";
  */
 export class ConcreteStacker implements Stacker {
   private repoPath: string;
-  private sourceControl: SourceControl;
   private collaborationPlatform: CollaborationPlatform;
+  private sourceControl: SourceControl;
 
   repositoryUpdateListener: StackerRepositoryUpdateListener;
+
+  private sourceControlRepositoryUpdateListener: SourceControlRepositoryUpdateListener = (
+    repo: Repository,
+  ) => {
+    this.repositoryUpdateListener(repo);
+  };
 
   constructor(
     repoPath: string,
     repositoryUpdateListener: StackerRepositoryUpdateListener,
-    sourceControl: SourceControl,
     collaborationPlatform: CollaborationPlatform,
+    sourceControlConstructor: (
+      stackerListener: SourceControlRepositoryUpdateListener,
+    ) => SourceControl,
   ) {
     this.repoPath = repoPath;
     this.repositoryUpdateListener = repositoryUpdateListener;
-    this.sourceControl = sourceControl;
     this.collaborationPlatform = collaborationPlatform;
+    this.sourceControl = sourceControlConstructor(
+      this.sourceControlRepositoryUpdateListener.bind(this),
+    );
   }
 
   loadRepositoryInformation(): void {

--- a/src/stacker/ConcreteStacker.ts
+++ b/src/stacker/ConcreteStacker.ts
@@ -61,6 +61,19 @@ export class ConcreteStacker implements Stacker {
   ): Promise<void> {
     // TODO: 1. Find all commits in the tree rooted at this commit.
 
+    // Some old code from useInteractionReducer that gets a stack rooted at
+    // `commit`s is below. It may be possible to update this to work with the
+    // new `childCommit` hashes (as it used to be `Commit` objects) and also
+    // adapt this to operate on trees.
+
+    // const stack = [];
+    // const nextCommits = [commit];
+    // while (nextCommits.length) {
+    //   const nextCommit = nextCommits.pop()!;
+    //   stack.push(nextCommit);
+    //   nextCommits.push(...nextCommit.childCommits);
+    // }
+
     // TODO: 2. Create or update PRs for all these commits.
 
     // 3. Update PR descriptions for all stacked PRs related to this commit.

--- a/src/stacker/index.ts
+++ b/src/stacker/index.ts
@@ -1,0 +1,2 @@
+export * from "./ConcreteStacker";
+export * from "./Stacker";


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #24 Create stub concrete classes for refactoring
- #25 Implement factory function to construct Stacker
- **#26 Update frontend to use new Stacker backend**

This PR breaks Stack Attack on master. If you want to use Stack Attack, you'll need to install and use the [version on NPM](https://www.npmjs.com/package/sttack) instead.

### Test Plan

`yarn cli` does not crash. I may have broken the frontend (specifically, the app exits immediately so I'm not sure if it'll wait for repo info to be fetched) but let's try this again when the backend is more fully implemented.

![image](https://user-images.githubusercontent.com/12784593/88356754-75e83a80-cd9b-11ea-9885-48df79e9e92b.png)
