### PR TITLE
Replace Meow with Commander and implement CLI commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.0.0",
+    "commander": "^6.0.0",
     "ink": "3.0.0-6",
-    "meow": "^7.0.1",
     "nodegit": "^0.26.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,32 +5,131 @@ import type { StackerRepositoryUpdateListener } from "../stacker";
 
 import React from "react";
 import { render } from "ink";
-import meow from "meow";
+import { Command } from "commander";
 
 import App from "./App";
 import { constructStacker } from "../shared/constructStacker";
 
-const cli = meow(`
-	Usage
-	  $ sttack [repoPath]
+const defaultRepoPath = process.cwd();
 
-	Examples
-	  $ sttack repoPath
-	  Hello, Jane
-`);
+const program = new Command();
 
-const repoPath = cli.input[0] ?? process.cwd();
+program
+  .name("sttack")
+  .description(
+    "Stack Attack: a CLI tool that helps you work with stacked pull requests.",
+  )
+  .on("--help", function () {
+    console.log("");
+    console.log("Examples:");
+    console.log("");
+    console.log("  $ sttack interactive");
+    console.log("  $ sttack interactive --repo ~/covid/vaccine");
+    console.log("  $ sttack i");
+    console.log("  $ sttack rebase 40cddfe b85b476");
+    console.log("  $ sttack pr-commit 40cddfe");
+    console.log("  $ sttack pr-stack 40cddfe");
+  });
 
-let repository: Repository | null = null;
+program
+  .command("interactive")
+  .alias("i")
+  .description("Stack Attack's interactive terminal UI")
+  .option("-r, --repo <repoPath>", "path to Git repository")
+  .action(({ repo = defaultRepoPath }: Command) => {
+    console.log("repo", repo);
 
-const repositoryUpdateListener: StackerRepositoryUpdateListener = (repo) => {
-  repository = repo;
-};
-const stacker = constructStacker(repoPath, repositoryUpdateListener);
-stacker.loadRepositoryInformation();
+    let repository: Repository | null = null;
 
-function reload() {
-  stacker.loadRepositoryInformation();
-}
+    const repositoryUpdateListener: StackerRepositoryUpdateListener = (
+      repo,
+    ) => {
+      repository = repo;
+    };
+    const stacker = constructStacker(repo, repositoryUpdateListener);
+    stacker.loadRepositoryInformation();
 
-render(React.createElement(App, { stacker, repository, reload }));
+    function reload() {
+      stacker.loadRepositoryInformation();
+    }
+
+    render(React.createElement(App, { stacker, repository, reload }));
+  });
+
+program
+  .command("rebase <rebaseRootCommit> <rebaseTargetCommit>")
+  .alias("r")
+  .description("replay a commit tree onto another commit")
+  .option("-r, --repo <repoPath>", "path to Git repository")
+  .action(
+    async (
+      rebaseRootCommitHash: string,
+      rebaseTargetCommitHash: string,
+      { repo = defaultRepoPath }: Command,
+    ) => {
+      const stacker = constructStacker(repo, () => {});
+      const rebaseRootCommit = await stacker.getCommitByHash(
+        rebaseRootCommitHash,
+      );
+      if (!rebaseRootCommit) {
+        console.error(`Commit ${rebaseRootCommitHash} could not be found.`);
+        return;
+      }
+      const targetCommit = await stacker.getCommitByHash(
+        rebaseTargetCommitHash,
+      );
+      if (!targetCommit) {
+        console.error(`Commit ${rebaseTargetCommitHash} could not be found.`);
+        return;
+      }
+      await stacker.rebaseCommits(rebaseRootCommit, targetCommit);
+    },
+  );
+
+// program
+//   .command("amend")
+//   .alias("a")
+//   .description(
+//     "amend a commit and rebase all commits originally above it onto the new commit",
+//   )
+//   .option("-r, --repo <repoPath>", "path to Git repository")
+//   .action(async ({ repo = defaultRepoPath }: Command) => {
+//     const stacker = constructStacker(repo, () => {});
+//     await stacker.amendAndRebase();
+//   });
+
+program
+  .command("pr-commit <commit>")
+  .alias("prc")
+  .description("create/update a PR for the given commit")
+  .option("-r, --repo <repoPath>", "path to Git repository")
+  .action(async (commitHash: string, { repo = defaultRepoPath }: Command) => {
+    const stacker = constructStacker(repo, () => {});
+    const baseCommit = await stacker.getCommitByHash(commitHash);
+    if (!baseCommit) {
+      console.error(`Commit ${commitHash} could not be found.`);
+      return;
+    }
+    await stacker.createOrUpdatePRContentsForSingleCommit(baseCommit);
+  });
+
+program
+  .command("pr-stack <commit>")
+  .alias("prs")
+  .description(
+    "create/update a PR for a commit stack based on the given commit",
+  )
+  .option("-r, --repo <repoPath>", "path to Git repository")
+  .action(async (commitHash: string, { repo = defaultRepoPath }: Command) => {
+    const stacker = constructStacker(repo, () => {});
+    const baseCommit = await stacker.getCommitByHash(commitHash);
+    if (!baseCommit) {
+      console.error(`Commit ${commitHash} could not be found.`);
+      return;
+    }
+    await stacker.createOrUpdatePRContentsForCommitTreeRootedAtCommit(
+      baseCommit,
+    );
+  });
+
+program.parse(process.argv);

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -1,4 +1,4 @@
-import type { Commit } from "../shared/types";
+import type { Commit, CommitHash } from "../shared/types";
 import type {
   SourceControl,
   SourceControlRepositoryUpdateListener,
@@ -19,6 +19,11 @@ export class GitSourceControl implements SourceControl {
 
   loadRepositoryInformation(): void {
     // TODO: Implement
+  }
+
+  async getCommitByHash(hash: CommitHash): Promise<Commit | null> {
+    // TODO: Implement
+    return null;
   }
 
   async rebaseCommits(

--- a/src/source-control/SourceControl.ts
+++ b/src/source-control/SourceControl.ts
@@ -1,4 +1,4 @@
-import type { Repository, Commit } from "../shared/types";
+import type { Repository, Commit, CommitHash } from "../shared/types";
 
 export type SourceControlRepositoryUpdateListener = (repo: Repository) => void;
 
@@ -19,6 +19,20 @@ export interface SourceControl {
    * changes.
    */
   loadRepositoryInformation(): void;
+
+  /**
+   * Get a commit by its unique hash (or a unique prefix of its hash), or null
+   * if one cannot be found.
+   *
+   * For example, if our repository had 2 commits with the hashes "abcdefghi"
+   * and "abcdwxyz":
+   *
+   * - getCommitByHash("abcdefghi") -> Commit with exact hash "abcdefghi"
+   * - getCommitByHash("abcde") -> Commit with hash "abcdefghi"
+   * - getCommitByHash("abcd") -> null, since this prefix is not unique
+   * - getCommitByHash("a") -> null
+   */
+  getCommitByHash(hash: CommitHash): Promise<Commit | null>;
 
   /**
    * Uproot a commit tree and rebase it onto `targetCommit`.

--- a/src/stacker/ConcreteStacker.ts
+++ b/src/stacker/ConcreteStacker.ts
@@ -1,4 +1,4 @@
-import type { Commit, Repository } from "../shared/types";
+import type { Commit, Repository, CommitHash } from "../shared/types";
 import type {
   SourceControl,
   SourceControlRepositoryUpdateListener,
@@ -45,11 +45,12 @@ export class ConcreteStacker implements Stacker {
     // TODO: Implement
   }
 
-  async rebaseCommits(
-    rebaseRootCommit: Commit,
-    targetCommit: Commit,
-  ): Promise<void> {
-    // TODO: Implement
+  getCommitByHash(hash: CommitHash): Promise<Commit | null> {
+    return this.sourceControl.getCommitByHash(hash);
+  }
+
+  rebaseCommits(rebaseRootCommit: Commit, targetCommit: Commit): Promise<void> {
+    return this.sourceControl.rebaseCommits(rebaseRootCommit, targetCommit);
   }
 
   async createOrUpdatePRContentsForSingleCommit(commit: Commit): Promise<void> {

--- a/src/stacker/Stacker.ts
+++ b/src/stacker/Stacker.ts
@@ -1,4 +1,4 @@
-import type { Repository, Commit } from "../shared/types";
+import type { Repository, Commit, CommitHash } from "../shared/types";
 
 export type StackerRepositoryUpdateListener = (repo: Repository) => void;
 
@@ -19,6 +19,11 @@ export interface Stacker {
    * changes.
    */
   loadRepositoryInformation(): void;
+
+  /**
+   * Get a commit by its hash.
+   */
+  getCommitByHash(hash: CommitHash): Promise<Commit | null>;
 
   /**
    * Uproot a commit tree and rebase it onto `targetCommit`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,6 +1870,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.0.0.tgz#2b270da94f8fb9014455312f829a1129dbf8887e"
+  integrity sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"


### PR DESCRIPTION
1. Replace Meow with Commander as Commander is much more powerful.
1. Implement (most) new CLI commands as listed in our HackMD document. The new commands call `stacker` methods.
1. Add `getCommitByHash` methods to both `Stacker` and `SourceControl`.

Please merge after you've reviewed it :)

## Test Plan

`yarn cli i` = the old `yarn cli`

![image](https://user-images.githubusercontent.com/12784593/88412180-be3f4100-ce0b-11ea-81da-d764651ed164.png)


`yarn cli` shows help

![image](https://user-images.githubusercontent.com/12784593/88412115-a071dc00-ce0b-11ea-9841-e8132b198863.png)

`yarn cli r ...` tries to run a rebase but fails as expected because `ConcreteStacker` is incomplete.

![image](https://user-images.githubusercontent.com/12784593/88412144-b089bb80-ce0b-11ea-893b-120eac7d2b6d.png)
