### PR TITLE
Get Commit by Partial Hash

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,7 +31,6 @@ export interface Commit {
   committer: CommitSignature;
 
   refNames: RefName[];
-  pullRequestInfo?: PullRequestInfo | undefined;
 
   parentCommits: CommitHash[];
   childCommits: CommitHash[];

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -62,7 +62,6 @@ export class GitSourceControl implements SourceControl {
     if (!this.repo) {
       await this.populateGitSourceControl();
     }
-    console.log(this.repo.commits.get("7960f25"));
     this.repositoryUpdateListener(this.repo);
   }
 
@@ -192,10 +191,6 @@ export class GitSourceControl implements SourceControl {
       earliestInterestingCommit,
       commits: commitHashMap,
     };
-    fs.writeFileSync(
-      "commits.json",
-      JSON.stringify(Array.from(commitHashMap.values()), undefined, 4),
-    );
     this.repo = ourRepository;
   }
 

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -199,8 +199,9 @@ export class GitSourceControl implements SourceControl {
       const repo = await nodegit.Repository.open(this.repoPath);
       const commit = await nodegit.AnnotatedCommit.fromRevspec(repo, hash);
       const completeCommitHash = commit.id().tostrS();
-      return this.repo.commits.get(completeCommitHash) || null;
+      return this.repo.commits.get(completeCommitHash) ?? null;
     } catch (err) {
+      console.log(err.message);
       return null;
     }
   }

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -211,19 +211,13 @@ export class GitSourceControl implements SourceControl {
   }
 
   async getCommitByHash(hash: CommitHash): Promise<Commit | null> {
-    // TODO: Implement for partial match
-    const relatedCommits: Commit[] = [];
-    const keys = Array.from(this.repo.commits.keys());
-    keys.forEach((key) => {
-      if (key.indexOf(hash) !== -1) {
-        // If hash in key, as the key was from the commits' key, it should be present
-        relatedCommits.push(this.repo.commits.get(key)!);
-      }
-    });
-    if (relatedCommits.length !== 1) {
+    try {
+      const repo = await nodegit.Repository.open(this.repoPath);
+      const commit = await nodegit.AnnotatedCommit.fromRevspec(repo, hash);
+      const completeCommitHash = commit.id().tostrS();
+      return this.repo.commits.get(completeCommitHash) || null;
+    } catch (err) {
       return null;
-    } else {
-      return relatedCommits[0];
     }
   }
 


### PR DESCRIPTION
Solves #36 

# Summary

It is as described in the issue, we walk the whole graph and store commits (as well as their relationships) in the repository object on GitSourceControl.

Having done this, we can use `nodegit` (particularly [`AnnotatedCommit.fromRevspec`](https://www.nodegit.org/api/annotated_commit/#fromRevspec)) to obtain the complete commit hash from the partial hash.

After having obtained the complete commit hash, we can simply lookup the commit on our graph, which would definitely exist as we traverse the entire graph while populating our repo as opposed to us populating till `earliestInterestingCommit`. 

# Testing plan

 - Wrote the map into a separate file to check if all the commits are being stored in our map ✅ 