### PR TITLE
updatePRDescriptionsForCompleteTreeContainingCommit: Complete Stack Retreival

### DIFF
--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -203,15 +203,17 @@ export class GitSourceControl implements SourceControl {
       .readFileSync(`${this.repoPath}/sttack.config.json`)
       .toString();
     const { longLivedBranches } = JSON.parse(configFileContents);
-    return longLivedBranches;
+    return longLivedBranches ?? [];
   }
 
-  async getMergeCommitByCommitHash(commit: Commit): Promise<CommitHash[]> {
+  async getMergeBasesWithLongLivedBranches(
+    commit: Commit,
+  ): Promise<CommitHash[]> {
     const repo = await nodegit.Repository.open(this.repoPath);
-    const longlivedbranches: BranchName[] = this.getLongLivedBranchesFromConfig();
+    const longLivedBranchNames: BranchName[] = this.getLongLivedBranchesFromConfig();
     const commitOid = nodegit.Oid.fromString(commit.hash);
     return await Promise.all(
-      longlivedbranches.map(async (branchName) => {
+      longLivedBranchNames.map(async (branchName) => {
         const branchTipCommitOid = await nodegit.Reference.nameToId(
           repo,
           branchName,
@@ -225,6 +227,7 @@ export class GitSourceControl implements SourceControl {
       }),
     );
   }
+
   async getCommitByHash(hash: CommitHash): Promise<Commit | null> {
     try {
       const repo = await nodegit.Repository.open(this.repoPath);

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -198,7 +198,7 @@ export class GitSourceControl implements SourceControl {
     this.repo = ourRepository;
   }
 
-  private getLLBFromConfig(): BranchName[] {
+  private getLongLivedBranchesFromConfig(): BranchName[] {
     const configFileContents = fs
       .readFileSync(`${this.repoPath}/sttack.config.json`)
       .toString();

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -208,7 +208,7 @@ export class GitSourceControl implements SourceControl {
 
   async getMergeCommitByCommitHash(commit: Commit): Promise<CommitHash[]> {
     const repo = await nodegit.Repository.open(this.repoPath);
-    const longlivedbranches: BranchName[] = this.getLLBFromConfig(); //TODO: Get long lived branches from sttack.config.json
+    const longlivedbranches: BranchName[] = this.getLongLivedBranchesFromConfig();
     const commitOid = nodegit.Oid.fromString(commit.hash);
     return await Promise.all(
       longlivedbranches.map(async (branchName) => {

--- a/src/source-control/SourceControl.ts
+++ b/src/source-control/SourceControl.ts
@@ -40,9 +40,10 @@ export interface SourceControl {
   getCommitByHash(hash: CommitHash): Promise<Commit | null>;
 
   /**
-   * Get all the merge-base commit hashes on the long lived branches for a given commit 
+   * Get all the merge-base commit hashes between `commit` and all
+   * (user-defined) long-lived branches.
    */
-  getMergeCommitByCommitHash(commit: Commit) : Promise<CommitHash[]>;
+  getMergeBasesWithLongLivedBranches(commit: Commit): Promise<CommitHash[]>;
 
   /**
    * Uproot a commit tree and rebase it onto `targetCommit`.

--- a/src/source-control/SourceControl.ts
+++ b/src/source-control/SourceControl.ts
@@ -40,6 +40,11 @@ export interface SourceControl {
   getCommitByHash(hash: CommitHash): Promise<Commit | null>;
 
   /**
+   * Get all the merge-base commit hashes on the long lived branches for a given commit 
+   */
+  getMergeCommitByCommitHash(commit: Commit) : Promise<CommitHash[]>;
+
+  /**
    * Uproot a commit tree and rebase it onto `targetCommit`.
    *
    * Calls `repositoryUpdateListener` on success.

--- a/src/stacker/ConcreteStacker.ts
+++ b/src/stacker/ConcreteStacker.ts
@@ -146,9 +146,9 @@ export class ConcreteStacker implements Stacker {
     const mergeBaseCommitHashes = await this.sourceControl.getMergeCommitByCommitHash(
       commit,
     ); //Question: what if the commit is on the same branch as the mergeBaseCommit?
-    //Should one not be looking for a merge base commit then? Description update stopped working, reason? Did I fuck up something? 
+    //Should one not be looking for a merge base commit then? Description update stopped working, reason? Did I fuck up something?
     let parentCommitHashes = commit.parentCommits;
-    let currentCommitHash = commit.hash; 
+    let currentCommitHash = commit.hash;
     let baseCommit;
     while (parentCommitHashes.length) {
       const parentCommitHash = parentCommitHashes.pop();
@@ -156,7 +156,9 @@ export class ConcreteStacker implements Stacker {
         (commitHash) => commitHash === parentCommitHash,
       );
       if (baseCommitHash) {
-        baseCommit = await this.sourceControl.getCommitByHash(currentCommitHash);
+        baseCommit = await this.sourceControl.getCommitByHash(
+          currentCommitHash,
+        );
         console.log("CURRENT COMMIT:", baseCommit);
         break;
       }
@@ -164,13 +166,12 @@ export class ConcreteStacker implements Stacker {
         const parentCommit = await this.sourceControl.getCommitByHash(
           parentCommitHash,
         );
-        if (parentCommit && parentCommit.parentCommits.length){
+        if (parentCommit && parentCommit.parentCommits.length) {
           parentCommitHashes = parentCommitHashes.concat(
             parentCommit.parentCommits,
           );
           currentCommitHash = parentCommit.hash;
         }
-          
       }
     }
     const nextCommits = [baseCommit];
@@ -200,7 +201,7 @@ export class ConcreteStacker implements Stacker {
       stack.map(async (commit) => {
         const branchName = nullthrows(
           this.sourceControl.getSttackBranchForCommit(commit),
-          "Violation of prerequisite: updatePRDescriptionsForCompleteTreeContainingCommit requires commits to have its Stack Attack branch already pushed to the remote.",
+          "Violation of prerequisite: all commits in `stack` must have their Stack Attack branch already pushed to the remote.",
         );
         const prInfo = await this.collaborationPlatform.getPRForCommitByBranchName(
           commit.hash,

--- a/src/stacker/ConcreteStacker.ts
+++ b/src/stacker/ConcreteStacker.ts
@@ -142,11 +142,10 @@ export class ConcreteStacker implements Stacker {
     commit: Commit,
   ): Promise<void> {
     const stack = [];
-    //TODO: Implement a complete version of the stack that start from the merge-base commit and also takes into consideration landed PRs
+    //Implement a complete version of the stack that start from the merge-base commit and also takes into consideration landed PRs
     const mergeBaseCommitHashes = await this.sourceControl.getMergeCommitByCommitHash(
       commit,
-    ); //Question: what if the commit is on the same branch as the mergeBaseCommit?
-    //Should one not be looking for a merge base commit then? Description update stopped working, reason? Did I fuck up something?
+    ); 
     let parentCommitHashes = [...commit.parentCommits];
     let currentCommitHash = commit.hash;
     let baseCommit;
@@ -159,7 +158,6 @@ export class ConcreteStacker implements Stacker {
         baseCommit = await this.sourceControl.getCommitByHash(
           currentCommitHash,
         );
-        console.log("CURRENT COMMIT:", baseCommit);
         break;
       }
       if (parentCommitHash) {
@@ -178,7 +176,6 @@ export class ConcreteStacker implements Stacker {
     const nextCommits = [baseCommit];
     while (nextCommits.length) {
       // Push commit onto stack
-      console.log("NEXT COMMIT:", nextCommits);
       const nextCommit = nextCommits.pop()!;
       stack.push(nextCommit);
 
@@ -196,7 +193,6 @@ export class ConcreteStacker implements Stacker {
       );
       nextCommits.push(...childCommits);
     }
-    console.log("Stack: ", stack);
 
     const commitNullablePrInfoPairs = await Promise.all(
       stack.map(async (commit) => {

--- a/src/stacker/ConcreteStacker.ts
+++ b/src/stacker/ConcreteStacker.ts
@@ -45,8 +45,8 @@ export class ConcreteStacker implements Stacker {
 
   async loadRepositoryInformation(): Promise<void> {
     await this.sourceControl.loadRepositoryInformation();
-    // TODO: Find PR info to load Pr info
-    // TODDO: SLoad PR info
+    // TODO: Find PR info to load PR info
+    // TODO: Load PR info
   }
 
   getCommitByHash(hash: CommitHash): Promise<Commit | null> {
@@ -141,61 +141,102 @@ export class ConcreteStacker implements Stacker {
   private async updatePRDescriptionsForCompleteTreeContainingCommit(
     commit: Commit,
   ): Promise<void> {
-    const stack = [];
-    //Implement a complete version of the stack that start from the merge-base commit and also takes into consideration landed PRs
-    const mergeBaseCommitHashes = await this.sourceControl.getMergeCommitByCommitHash(
+    // Perform *breadth*-first search to find root of the complete tree
+    // containing `commit`. Search starts from `commit` and goes down the commit
+    // graph. We stop when we reach the tree root, i.e. the first merge-base
+    // commit between `commit` and any long-lived branch.
+    const mergeBaseCommitHashes = await this.sourceControl.getMergeBasesWithLongLivedBranches(
       commit,
-    ); 
-    let parentCommitHashes = [...commit.parentCommits];
+    );
+    let nextParentCommitHashes: CommitHash[] = [...commit.parentCommits];
     let currentCommitHash = commit.hash;
-    let baseCommit;
-    while (parentCommitHashes.length) {
-      const parentCommitHash = parentCommitHashes.pop();
-      const baseCommitHash = mergeBaseCommitHashes.find(
-        (commitHash) => commitHash === parentCommitHash,
-      );
-      if (baseCommitHash) {
-        baseCommit = await this.sourceControl.getCommitByHash(
-          currentCommitHash,
+    let treeRootCommit: Commit | null | undefined; // What we're searching for
+    while (nextParentCommitHashes.length) {
+      const [parentCommitHash] = nextParentCommitHashes.splice(0, 1);
+
+      // Stop if we've found the tree root
+      if (mergeBaseCommitHashes.includes(parentCommitHash)) {
+        // The tree root is the child of this parent (because the parent is on
+        // the base branch, it's not part of the tree to be updated).
+        treeRootCommit = nullthrows(
+          await this.sourceControl.getCommitByHash(currentCommitHash),
+          `A tree root commit hash ${parentCommitHash} from sourceControl should have an actual backing commit`,
         );
         break;
       }
-      if (parentCommitHash) {
-        const parentCommit = await this.sourceControl.getCommitByHash(
-          parentCommitHash,
-        );
-        if (parentCommit && parentCommit.parentCommits.length) {
-          parentCommitHashes = [
-            ...parentCommitHashes,
-            ...parentCommit.parentCommits,
-          ];
-          currentCommitHash = parentCommit.hash;
-        }
-      }
+
+      const parentCommit = nullthrows(
+        await this.sourceControl.getCommitByHash(parentCommitHash),
+        `A parent commit hash ${parentCommitHash} from sourceControl should have an actual backing commit`,
+      );
+      nextParentCommitHashes = [
+        ...nextParentCommitHashes,
+        ...parentCommit.parentCommits,
+      ];
+
+      // FIXME: The following line of code causes this BFS to produce the wrong
+      // tree root if `parentCommit`'s parent has multiple children.
+      //
+      // Take the following commit graph:
+      // * A
+      // |\
+      // | * B
+      // *   C
+      //
+      // Before the loop starts, the variables are initialized as such:
+      // - nextParentCommitHashes = [B, C]
+      // - currentCommitHash = A
+      //
+      // During the first iteration, before the following line of code is
+      // executed:
+      // - currentCommitHash = A
+      // - parentCommit = B
+      // - nextParentCommitHashes = [C]
+      //
+      // The following line of code will then set:
+      // currentCommitHash = parentCommit = B
+      //
+      // The second iteration will thus have the following variables:
+      // - currentCommitHash = B
+      // - parentCommit = C (dequeued from nextParentCommitHashes)
+      //
+      // Because C is not a parent of B, we've violated our (implicitly assumed)
+      // loop invariants (that parentCommit is a parent of currentCommitHash).
+      // More practically, if C is on a long lived branch, this search will
+      // output B as the tree root, when it should be A.
+      currentCommitHash = parentCommit.hash;
     }
-    const nextCommits = [baseCommit];
+
+    // TODO: Figure out a way to handle the case when we reached the end of the
+    // commit history without finding a tree root. Update everything?
+    treeRootCommit = nullthrows(
+      treeRootCommit,
+      "A tree root could not be found!",
+    );
+
+    // Build the commit tree up from the tree root by *depth*-first search
+    const linearCommitTree = []; // We don't care about the tree structure so we just store it as a list
+    const nextCommits = [treeRootCommit];
     while (nextCommits.length) {
-      // Push commit onto stack
+      // Push commit into tree
       const nextCommit = nextCommits.pop()!;
-      stack.push(nextCommit);
+      linearCommitTree.push(nextCommit);
 
       // Find next commits
-      const nullableChildCommits = await Promise.all(
-        nextCommit.childCommits.map((commitHash) =>
-          this.sourceControl.getCommitByHash(commitHash),
-        ),
-      );
-      const childCommits = nullableChildCommits.map((commit) =>
-        nullthrows(
-          commit,
-          "Commit must exist if we got the commit from the repository.",
+      const childCommits = await Promise.all(
+        nextCommit.childCommits.map(async (commitHash) =>
+          nullthrows(
+            await this.sourceControl.getCommitByHash(commitHash),
+            "Commit must exist as we got the commit from the repository.",
+          ),
         ),
       );
       nextCommits.push(...childCommits);
     }
 
+    // Get PRs to be updated
     const commitNullablePrInfoPairs = await Promise.all(
-      stack.map(async (commit) => {
+      linearCommitTree.map(async (commit) => {
         const branchName = this.sourceControl.getSttackBranchForCommit(commit);
         return {
           commit,
@@ -209,13 +250,13 @@ export class ConcreteStacker implements Stacker {
       }),
     );
     const commitPrInfoPairs = commitNullablePrInfoPairs
-      .filter(({ prInfo }) => !!prInfo) // Commits may not have PRs opened
+      .filter(({ prInfo }) => !!prInfo) // Commits may not have associated PRs
       .map(({ commit, prInfo }) => ({
         commit,
         prInfo: nullthrows(prInfo, "null prInfo should have been filtered out"),
       }));
 
-    return this.collaborationPlatform.updatePRDescriptionsForCommitGraph(
+    await this.collaborationPlatform.updatePRDescriptionsForCommitGraph(
       commitPrInfoPairs,
     );
   }


### PR DESCRIPTION
**Summary**
Complete the PR stack for updating the PRs 

**Changelog**
- Add a parameter to the sttack.config.json i.e 'longLivedBranches: []` This currently stores the ref names for the long lived branches. A future update could be to store branch names and convert the branch name to ref name for getting the merge base commit. 
- Add a function to get the merge base commits in `GitSourceControl` 
- Updating the code to start from the first child of the merge base commit to update the whole PR Description Stack 

