### PR TITLE
Fix graph lines for commits with >2 children

### DIFF
--- a/src/cli/useInteractionReducer.ts
+++ b/src/cli/useInteractionReducer.ts
@@ -80,11 +80,19 @@ function backendCommitGraphToDisplayCommits(
       a.timestamp > b.timestamp ? 1 : -1,
     );
     const childDisplayCommits = sortedChildren.flatMap((child, index) => {
-      const forkIndex = sortedChildren.length - index - 1;
+      // Last child appears linearly with its parent; every other child forks
+      // from the main line. Example:
+      // * Child 2
+      // | * Child 1
+      // |/
+      // | * Child 0
+      // |/
+      // * Parent
+      const hasFork = index !== sortedChildren.length - 1;
       return displayCommitsForSubgraphRootedAtCommit(
         child,
-        depth + forkIndex,
-        forkIndex !== 0,
+        depth + (hasFork ? 1 : 0),
+        hasFork,
       );
     });
 


### PR DESCRIPTION
Fixes #47.

## Test Plan

Using this repository: https://github.com/24r/stack-attack-multiple-children

Git's graph:
![image](https://user-images.githubusercontent.com/12784593/90327360-8e77f900-dfc5-11ea-9e3d-e61466442d0e.png)


Stack Attack, before this PR:
![image](https://user-images.githubusercontent.com/12784593/90327356-83bd6400-dfc5-11ea-843f-f27255a56bea.png)

Stack Attack, after this PR:
![image](https://user-images.githubusercontent.com/12784593/90327454-5fae5280-dfc6-11ea-9d93-5d5e540adecd.png)
