### PR TITLE
Rebase Trees and avoiding linearisation of rebased commits

### DIFF
--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -239,10 +239,7 @@ export class GitSourceControl implements SourceControl {
       // rebase cannot happen
       targetCommitHash = nullthrows(
         rebaseTargetHashMap.get(hashOfCommitToBeRebased),
-        `Target commit for ${hashOfCommitToBeRebased.slice(
-          0,
-          6,
-        )} could not be found `,
+        `Target commit for ${hashOfCommitToBeRebased} could not be found`,
       );
       const commitToBeRebased = nullthrows(
         this.repo.commits.get(hashOfCommitToBeRebased),
@@ -339,8 +336,8 @@ export class GitSourceControl implements SourceControl {
 
       queue.push(...commitToBeRebased.childCommits);
 
-      // We now would want to use this new commit hash as the target for all of it's children
-      commitToBeRebased.childCommits.map((childCommitHash: CommitHash) => {
+      // Register new commit as the rebase target for all children
+      commitToBeRebased.childCommits.forEach((childCommitHash) => {
         rebaseTargetHashMap.set(childCommitHash, newCommitOid.tostrS());
       });
     }


### PR DESCRIPTION
# Summary

Resolves #59 

This approach helps us to rebase trees rather than linearising them as we have been so far, which is a major bug in the rebase implementation.

We use a hashmap to keep track of the target commit hash. This allows us to select the commit to be rebased on. The use of the hashmap allows us to rebase arbitrary trees and retain their structure on the target commits, hence almost identically mimicking a rebase.

# Testing plan

- Initial State

On Stack Attack
![stack-attack-initial](https://user-images.githubusercontent.com/31125345/90331765-bfabf580-dfd4-11ea-8b86-96c2f07da378.png)
On Git Logs
<img width="295" alt="git-initial" src="https://user-images.githubusercontent.com/31125345/90331767-c63a6d00-dfd4-11ea-962c-9f62f2cee21f.png">

- Final State

Upon rebasing `4d78fd` (Commit Message: 2nd File) on `5b244c` (Commit Message: 4th File), we get

On Stack Attack
![stack-attack-final](https://user-images.githubusercontent.com/31125345/90331792-f8e46580-dfd4-11ea-9549-19b9504b05ec.png)
On Git Log
<img width="295" alt="git-final" src="https://user-images.githubusercontent.com/31125345/90331797-ff72dd00-dfd4-11ea-935b-22cacdf91307.png"> 

# Notes

This still does not solve the problem of merge commits which can have multiple parents, as can be seen in the line `rebaseTargetHashMap.set(childCommitHash, newCommitOid.tostrS())`. In the case of merge commits, the merge commit's parent will be resolved to an indeterminate parent, which may be a bug to be addressed in the future.

