### PR TITLE
Stack Attack branches track remote branches upon pushing to remote

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,6 +16,7 @@ export interface PullRequestInfo {
 export type CommitHash = string;
 export type RefName = string;
 export type BranchName = string;
+export type RemoteName = string;
 
 export interface CommitSignature {
   name: string;

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -362,7 +362,6 @@ export class GitSourceControl implements SourceControl {
         fs.readFileSync(`${this.repoPath}/sttack.config.json`, "utf-8"),
       );
       const repo = await nodegit.Repository.open(this.repoPath);
-      // SEE: Could be any of the long lived branches?
       const remote = await repo.getRemote(remoteName);
       const refName = branchNameToLocalRef(branchName);
       const branchReference = nullthrows(

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -351,7 +351,7 @@ export class GitSourceControl implements SourceControl {
 
   async pushBranch(
     branchName: BranchName,
-    remoteName: RemoteName = "origin",
+    remoteName = "origin",
   ): Promise<void> {
     try {
       const {
@@ -366,7 +366,11 @@ export class GitSourceControl implements SourceControl {
       const remote = await repo.getRemote(remoteName);
       const refName = branchNameToLocalRef(branchName);
       const branchReference = nullthrows(
-        await nodegit.Branch.lookup(repo, refName, nodegit.Branch.BRANCH.LOCAL),
+        await nodegit.Branch.lookup(
+          repo,
+          branchName,
+          nodegit.Branch.BRANCH.LOCAL,
+        ),
         `Branch with name ${branchName} could not be found`,
       );
       const callback = {

--- a/src/source-control/GitSourceControl.ts
+++ b/src/source-control/GitSourceControl.ts
@@ -12,6 +12,7 @@ import type {
   CommitSignature,
   Repository,
   RefName,
+  RemoteName,
 } from "../shared/types";
 import type {
   SourceControl,
@@ -348,7 +349,10 @@ export class GitSourceControl implements SourceControl {
     await this.populateGitSourceControl();
   }
 
-  async pushBranch(branchName: BranchName): Promise<void> {
+  async pushBranch(
+    branchName: BranchName,
+    remoteName: RemoteName = "origin",
+  ): Promise<void> {
     try {
       const {
         userPublicKeyPath,
@@ -359,7 +363,12 @@ export class GitSourceControl implements SourceControl {
       );
       const repo = await nodegit.Repository.open(this.repoPath);
       // SEE: Could be any of the long lived branches?
-      const remote = await repo.getRemote("origin");
+      const remote = await repo.getRemote(remoteName);
+      const refName = branchNameToLocalRef(branchName);
+      const branchReference = nullthrows(
+        await nodegit.Branch.lookup(repo, refName, nodegit.Branch.BRANCH.LOCAL),
+        `Branch with name ${branchName} could not be found`,
+      );
       const callback = {
         credentials: function (_url: string, userName: string) {
           //console.log("Getting credentials");
@@ -374,8 +383,11 @@ export class GitSourceControl implements SourceControl {
           );
         },
       };
-      const refName = branchNameToLocalRef(branchName);
       await remote.push([`+${refName}:${refName}`], { callbacks: callback });
+      await nodegit.Branch.setUpstream(
+        branchReference,
+        `${remoteName}/${branchName}`,
+      );
     } catch (err) {
       console.log(err);
     }

--- a/src/source-control/SourceControl.ts
+++ b/src/source-control/SourceControl.ts
@@ -59,7 +59,7 @@ export interface SourceControl {
    * @param branchName Name of the branch to be pushed
    * @param remoteName Name of the remote that the branch should be pushed on (defaults to 'origin')
    */
-  pushBranch(branchName: BranchName, remoteName: RemoteName): Promise<void>;
+  pushBranch(branchName: BranchName, remoteName?: RemoteName): Promise<void>;
 
   /**
    * Gets the Stack Attack branch for `commit` if the commit has one, otherwise

--- a/src/source-control/SourceControl.ts
+++ b/src/source-control/SourceControl.ts
@@ -3,6 +3,7 @@ import type {
   Commit,
   CommitHash,
   BranchName,
+  RemoteName,
 } from "../shared/types";
 
 export type SourceControlRepositoryUpdateListener = (repo: Repository) => void;
@@ -53,7 +54,12 @@ export interface SourceControl {
     targetCommit: CommitHash,
   ): Promise<void>;
 
-  pushBranch(branchName: BranchName): Promise<void>;
+  /**
+   * Push Branch pushes the provided branch Name on the provided remote, and sets up the pushed branch to track its remote counterpart
+   * @param branchName Name of the branch to be pushed
+   * @param remoteName Name of the remote that the branch should be pushed on (defaults to 'origin')
+   */
+  pushBranch(branchName: BranchName, remoteName: RemoteName): Promise<void>;
 
   /**
    * Gets the Stack Attack branch for `commit` if the commit has one, otherwise


### PR DESCRIPTION
# Summary

Resolves #62 

We needed to setup a command to track our remote branch, which was available in `nodegit` as the `Branch.setUpstream`. This sets up our newly created branch to track the remote branch that is pushed.

# Testing plan

- Before 
<img width="731" alt="pre" src="https://user-images.githubusercontent.com/31125345/90338700-1501fa00-e009-11ea-9d85-588663ea4c96.png">

- After pressing `s`
<img width="731" alt="post s" src="https://user-images.githubusercontent.com/31125345/90338703-1b907180-e009-11ea-919e-6b17ad0773c7.png">


To verify the validity, I checked out to one of the branches created by Stack Attack and `git status`-ed it to get
<img width="604" alt="Screenshot 2020-08-16 at 9 33 51 PM" src="https://user-images.githubusercontent.com/31125345/90338718-3367f580-e009-11ea-9c30-8f1ef1873134.png">


# Extra Notes

- Made remoteName a parameter in the push function with a default value of origin, nothing breaks and I think it somewhat makes it easy to implement remotes in the future.

# Notes

For more context refer to : https://github.com/nodegit/nodegit/issues/1261#issuecomment-431831338